### PR TITLE
Support 16 KB page size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Android woff2 typeface decoder
 ## Installation
 ```gradle
 # Woff2 android typeface converter
-implementation 'io.github.khoben.woff2-android:typeface:0.0.1'
+implementation 'io.github.khoben.woff2-android:typeface:0.0.2'
 
 # Or single native woff2 decoder
-implementation 'io.github.khoben.woff2-android:decoder:0.0.1'
+implementation 'io.github.khoben.woff2-android:decoder:0.0.2'
 ```
 
 ## Sample usage
@@ -44,7 +44,7 @@ class MainActivity : AppCompatActivity(R.layout.main_layout) {
     python ./scripts/build_ndk.py
     ```
 
-Make sure you have NDK version 23 and above.
+Make sure you have NDK version 28 and above.
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.github.khoben.woff2typeface"
         minSdk 21
-        targetSdk 32
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 
@@ -26,18 +26,21 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
+    kotlin {
+        jvmToolchain(8)
     }
+    namespace "com.github.khoben.woff2typeface"
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.12.0'
 
-    implementation 'io.github.khoben.woff2-android:typeface:0.0.1'
+     implementation 'io.github.khoben.woff2-android:typeface:0.0.2'
+//    implementation project(':woff2android')
+
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.khoben.woff2typeface">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
-    id 'org.jetbrains.kotlin.jvm' version '1.7.10' apply false
-    id 'com.vanniktech.maven.publish' version '0.18.0' apply false
+    id 'com.android.application' version '8.10.1' apply false
+    id 'com.android.library' version '8.10.1' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
+    id 'org.jetbrains.kotlin.jvm' version '2.2.0' apply false
+    id 'com.vanniktech.maven.publish' version '0.34.0' apply false
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.getLayout().getBuildDirectory()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.0' apply false
-    id 'com.android.library' version '7.2.0' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.7.10' apply false
     id 'com.vanniktech.maven.publish' version '0.18.0' apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ android.nonTransitiveRClass=true
 SONATYPE_HOST=S01
 
 GROUP=io.github.khoben.woff2-android
-VERSION_NAME=0.0.1
+VERSION_NAME=0.0.2
 
 POM_DESCRIPTION=Android woff2 typeface decoder
 POM_INCEPTION_YEAR=2022
@@ -42,3 +42,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=khoben
 POM_DEVELOPER_NAME=Vladimir Baev
 POM_DEVELOPER_URL=https://github.com/khoben
+
+mavenCentralPublishing=true
+signAllPublications=true
+mavenCentralAutomaticPublishing=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Aug 19 08:51:06 GMT+07:00 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Aug 19 08:51:06 GMT+07:00 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/libwoff2dec/build.gradle
+++ b/libwoff2dec/build.gradle
@@ -1,15 +1,16 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {
-    compileSdk 33
-    ndkVersion = "27.1.12297006"
+    compileSdk 35
+    ndkVersion "28.2.13676358"
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -37,15 +38,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
+    kotlin {
+        jvmToolchain(8)
     }
+    namespace "com.github.khoben.libwoff2dec"
 }
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }
-
-apply plugin: "com.vanniktech.maven.publish"

--- a/libwoff2dec/build.gradle
+++ b/libwoff2dec/build.gradle
@@ -4,17 +4,19 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
+    ndkVersion = "27.1.12297006"
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
         externalNativeBuild {
             cmake {
                 cppFlags ""
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }

--- a/libwoff2dec/src/main/AndroidManifest.xml
+++ b/libwoff2dec/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.github.khoben.libwoff2dec">
-
-</manifest>
+<manifest/>

--- a/scripts/build_ndk.properties
+++ b/scripts/build_ndk.properties
@@ -1,9 +1,11 @@
 WOFF2_REPO=https://github.com/google/woff2.git
 WOFF2_VERSION=v1.0.2
 ANDROID_SDK=Android SDK Path (ex, D:/Android/sdk)
-# {ANDROID_SDK}/ndk/{NDK_VERSION}
-NDK_VERSION=Android NDK Version (ex, 23.2.8568313)
-# {ANDROID_SDK}/cmake/{CMAKE_VERSION}
-# Preffered cmake version under Android SDK, will be prepend to PATH
-CMAKE_VERSION=Android NDK CMake Version (ex, 3.18.1)
+# Android NDK Version (ex, 28.2.13676358)
+# Path: {ANDROID_SDK}/ndk/{NDK_VERSION}
+NDK_VERSION=28.2.13676358
+# Android NDK CMake Version (ex, 3.18.1)
+# Path: {ANDROID_SDK}/cmake/{CMAKE_VERSION}
+# Preferred cmake version under Android SDK, will be prepend to PATH
+CMAKE_VERSION=3.18.1
 MIN_ANDROID_SDK=21

--- a/scripts/build_ndk.py
+++ b/scripts/build_ndk.py
@@ -78,6 +78,7 @@ def build_woff2() -> None:
         run(f'cmake -S {BROTLI_SOURCE_DIR} -B {BROTLI_BUILD_PATH}'
             f' -DCMAKE_INSTALL_PREFIX={BROTLI_PREFIX_PATH} -DCMAKE_BUILD_TYPE=Release'
             f' -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake'
+            f' -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
             f' -DANDROID_ABI={ABI} -DANDROID_NATIVE_API_LEVEL={MIN_ANDROID_SDK} -G Ninja')
         
         run(f'cmake --build {BROTLI_BUILD_PATH} --config Release --target install -j {CPU_COUNT}')
@@ -96,6 +97,7 @@ def build_woff2() -> None:
             f' -DBROTLIDEC_INCLUDE_DIRS={BROTLI_INCLUDE_DIR} -DBROTLIDEC_LIBRARIES={BROTLI_LIB_DIR}/libbrotlidec.so'
             f' -DBROTLIENC_INCLUDE_DIRS={BROTLI_INCLUDE_DIR} -DBROTLIENC_LIBRARIES={BROTLI_LIB_DIR}/libbrotlienc.so'
             f' -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake -DANDROID_ABI={ABI}'
+            f' -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
             f' -DANDROID_NATIVE_API_LEVEL={MIN_ANDROID_SDK} -G Ninja')
 
         run(f'cmake --build {WOFF2_BUILD_PATH} --config Release --target install -j {CPU_COUNT}')

--- a/woff2android/build.gradle
+++ b/woff2android/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/woff2android/build.gradle
+++ b/woff2android/build.gradle
@@ -1,14 +1,15 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {
-    compileSdk 33
+    compileSdk 35
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -24,19 +25,18 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
+    kotlin {
+        jvmToolchain(8)
     }
+    namespace "com.github.khoben.woff2android"
 }
 
 dependencies {
     implementation project(':libwoff2dec')
-    implementation 'com.github.solkin:disk-lru-cache:1.4'
-    implementation "androidx.startup:startup-runtime:1.1.1"
+    implementation 'com.github.khoben:disk-lru-cache:1.7.1'
+    implementation 'androidx.startup:startup-runtime:1.2.0'
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }
-
-apply plugin: "com.vanniktech.maven.publish"

--- a/woff2android/src/main/AndroidManifest.xml
+++ b/woff2android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.khoben.woff2android">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
         <provider


### PR DESCRIPTION
This is a requirement for submitting apps to Google Play from November 1st, 2025: https://developer.android.com/guide/practices/page-sizes

To be honest, I'm not sure if it was necessary to add `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` to both `build.gradle` and `build_ndk.py` . But both compiled without complaining using ndk version 27.1.12297006.